### PR TITLE
Drop requirement to have Jira ID in branch name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,10 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
         exclude: .+\.csv$
-      - id: no-commit-to-branch
-        name: JIRA ticket ID in branch
-        args: ['--pattern', '^((?![A-Z]+[-][0-9]+[-][\S]+).)*$']
+      # Useful if you want to enforce feature branches beginning with a Jira ticket ID
+      # - id: no-commit-to-branch
+      #   name: JIRA ticket ID in branch
+      #   args: ['--pattern', '^((?![A-Z]+[-][0-9]+[-][\S]+).)*$']
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:


### PR DESCRIPTION
This is useful to have in an org's pre-commit, not so useful in an open-source repo.