### PR TITLE
Pre-commit hook update 11319608664

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         args: ["--profile", "black", "--filter-files"]
         name: isort (python)
   - repo: https://github.com/ambv/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
         name: Run black formatter
@@ -35,7 +35,7 @@ repos:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.18.0
     hooks:
       - id: pyupgrade
         name: Check for code that can use new Python features


### PR DESCRIPTION
Created by Github action

## Summary by Sourcery

Update the pre-commit hook configuration to use the latest versions of Black and PyUpgrade, ensuring code formatting and Python feature usage checks are up-to-date.

Build:
- Update the pre-commit hook configuration to use Black version 24.10.0.
- Update the pre-commit hook configuration to use PyUpgrade version 3.18.0.