### PR TITLE
Improving docs on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  ######
+  #
+  # Standard hooks for any repo
+  #
+  #####
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -18,6 +23,12 @@ repos:
       # - id: no-commit-to-branch
       #   name: JIRA ticket ID in branch
       #   args: ['--pattern', '^((?![A-Z]+[-][0-9]+[-][\S]+).)*$']
+
+  ######
+  #
+  # Hooks for python files
+  #
+  #####
   - repo: local
     hooks:
       - id: isort
@@ -49,14 +60,12 @@ repos:
         name: Check for code that can use new Python features
         pass_filenames: true
         types_or: [python, pyi]
-  - repo: local
-    hooks:
-      - id: pytest-no-deps
-        name: pytest-no-deps
-        entry: pytest ./tests/pytest -m no_deps -n 5
-        language: system
-        pass_filenames: false
-        always_run: true
+
+  ######
+  #
+  # Hooks for dbt projects
+  #
+  #####
   - repo: local
     hooks:
       - id: sqlfmt
@@ -65,6 +74,20 @@ repos:
         name: Run sqlfmt
         pass_filenames: true
         types_or: [jinja, sql]
+
+  ######
+  #
+  # Custom hooks for dbt projects
+  #
+  #####
+  - repo: local
+    hooks:
+      - id: pytest-no-deps
+        name: pytest-no-deps
+        entry: pytest ./tests/pytest -m no_deps -n 5
+        language: system
+        pass_filenames: false
+        always_run: true
   - repo: local
     hooks:
       - id: pytest-catalog-json

--- a/README.md
+++ b/README.md
@@ -44,7 +44,21 @@ Continuous Integration (CI) is the process of codifying standards, these range f
 
 ## Pre-commit
 
-[Pre-commit](https://pre-commit.com/) provides a standardised process to run CI before committing to your local branch. This has several benefits, primarily providing the developer with a quick feedback loop on their work as well as ensuring changes that do not align with standards are automatically identified before being merged. Pre-commit operates via hooks, all of these hooks are sepecified in a `.pre-commit-config.yaml`file. There are several hooks that are relevant to a dbt project:
+[Pre-commit](https://pre-commit.com/) provides a standardised process to run some basic tests (generally formatting and linting) before committing to your local branch. This has several benefits, primarily providing the developer with a quick feedback loop on their work as well as ensuring changes that do not align with standards are automatically identified before being merged. Pre-commit operates via hooks, all of these hooks are sepecified in a `.pre-commit-config.yaml`file.
+
+To install `pre-commit` run:
+
+```shell
+pip install pre-commit
+```
+
+Then install the hooks specified in your `.pre-commit-config.yaml` file:
+
+```shell
+pre-commit install
+```
+
+There are several hooks that are relevant to a dbt project:
 
 - [Pre-commit](https://github.com/pre-commit/pre-commit-hooks) itself provides several standard hooks that ensure standard behaviour regarding whitespace control, valid YAML files, no presence of private keys and no unresolved merge conflicts. An interesting hook is `no-commit-to-branch`, this allows the name of the git branch to be standarised, for example to always start with `feature/` or to always include a Jira ticket ID to help with tracking of work items.
 
@@ -71,6 +85,8 @@ Continuous Integration (CI) is the process of codifying standards, these range f
         hooks:
         - id: sqlfmt
     ```
+
+For an example `.pre-commit-config.yaml` file, see the [file](https://github.com/pgoslatara/dbt-beyond-the-basics/blob/stg/.pre-commit-config.yaml) in this repository.
 
 ### The advantage of local hooks
 


### PR DESCRIPTION
Addresses #166.

* Breaks up `.pre-commit-config.yaml` into different sections.
* Updates `README.md` to point to `.pre-commit-config.yaml` as an example of a `pre-commit` file.
* Updates `README.md` to detail how to install `pre-commit`.